### PR TITLE
Fix criteria example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,11 @@ Here is a simple criteria:
 ```php
 <?php namespace App\Repositories\Criteria\Films;
 
-use Bosnadev\Repositories\Contracts\CriteriaInterface;
+use Bosnadev\Repositories\Criteria\Criteria;
 use Bosnadev\Repositories\Contracts\RepositoryInterface as Repository;
 use Bosnadev\Repositories\Contracts\RepositoryInterface;
 
-class LengthOverTwoHours implements CriteriaInterface {
+class LengthOverTwoHours extends Criteria {
 
     /**
      * @param $model


### PR DESCRIPTION
Unless I’m wrong, when creating a custom ‘Criteria’, the class has to extend the abstract Criteria, not implement CriteriaInterface (this last one is for repositories).

This PR updates the README accordingly.