### PR TITLE
Save a model without massive assignment

### DIFF
--- a/src/Contracts/RepositoryInterface.php
+++ b/src/Contracts/RepositoryInterface.php
@@ -18,12 +18,18 @@ interface RepositoryInterface {
      * @return mixed
      */
     public function paginate($perPage = 1, $columns = array('*'));
-    
+
     /**
      * @param array $data
      * @return mixed
      */
     public function create(array $data);
+
+    /**
+     * @param array $data
+     * @return bool
+     */
+    public function saveModel(array $data);
 
     /**
      * @param array $data

--- a/src/Eloquent/Repository.php
+++ b/src/Eloquent/Repository.php
@@ -96,6 +96,20 @@ abstract class Repository implements RepositoryInterface, CriteriaInterface {
     }
 
     /**
+     * save a model without massive assignment
+     *
+     * @param array $data
+     * @return bool
+     */
+    public function saveModel(array $data)
+    {
+        foreach ($data as $k => $v) {
+            $this->model->$k = $v;
+        }
+        return $this->model->save();
+    }
+
+    /**
      * @param array $data
      * @param $id
      * @param string $attribute


### PR DESCRIPTION
The create method works only when a column is in
the $fillable array. the saveModel method can save
any columns to a model

eg. $this->post->saveModel(['title' => 'test', 'author' => 'foo']);