### PR TITLE
Prevent Stratify feature

### DIFF
--- a/src/Console/Commands/Creators/RepositoryCreator.php
+++ b/src/Console/Commands/Creators/RepositoryCreator.php
@@ -170,6 +170,16 @@ class RepositoryCreator {
         return $model_name;
     }
 
+    protected function getRepositoryNamespace()
+    {
+        return Config::get('repositories.repository_namespace');
+    }
+
+    protected function getModelNamespace()
+    {
+        return Config::get('repositories.model_namespace');
+    }
+
     /**
      * Get the stripped repository name.
      *
@@ -198,13 +208,13 @@ class RepositoryCreator {
     protected function getPopulateData()
     {
         // Repository namespace.
-        $repository_namespace = Config::get('repositories.repository_namespace');
+        $repository_namespace = $this->getRepositoryNamespace();
 
         // Repository class.
         $repository_class     = $this->getRepositoryName();
 
         // Model path.
-        $model_path           = Config::get('repositories.model_namespace');
+        $model_path           = $this->getModelNamespace();
 
         // Model name.
         $model_name           = $this->getModelName();

--- a/src/Eloquent/Repository.php
+++ b/src/Eloquent/Repository.php
@@ -36,6 +36,12 @@ abstract class Repository implements RepositoryInterface, CriteriaInterface {
     protected $skipCriteria = false;
 
     /**
+     * Prevents from overwriting same criteria in chain usage
+     * @var bool
+     */
+    protected $preventCriteriaOverwriting = true;
+
+    /**
      * @param App $app
      * @param Collection $collection
      * @throws \Bosnadev\Repositories\Exceptions\RepositoryException
@@ -263,7 +269,23 @@ abstract class Repository implements RepositoryInterface, CriteriaInterface {
      * @param Criteria $criteria
      * @return $this
      */
-    public function pushCriteria(Criteria $criteria) {
+    public function pushCriteria(Criteria $criteria)
+    {
+        if ($this->preventCriteriaOverwriting)
+        {
+            // Find existing criteria
+            $key = $this->criteria->search(function($item) use ($criteria)
+            {
+                return (is_object($item) AND (get_class($item) == get_class($criteria)));
+            });
+
+            // Remove old criteria
+            if (is_int($key))
+            {
+                $this->criteria->offsetUnset($key);
+            }
+        }
+
         $this->criteria->push($criteria);
         return $this;
     }


### PR DESCRIPTION
When criteria has been added by default (in constructor) and we want to overwrite them with new one, this feature provides clearing the old one