### PR TITLE
Added updateOrCreate function

### DIFF
--- a/src/Contracts/RepositoryInterface.php
+++ b/src/Contracts/RepositoryInterface.php
@@ -39,6 +39,13 @@ interface RepositoryInterface {
     public function update(array $data, $id);
 
     /**
+     * @param array $searchData
+     * @param array $saveData
+     * @return mixed
+     */
+    public function updateOrCreate(array $searchData, array $saveData = []);
+
+    /**
      * @param $id
      * @return mixed
      */

--- a/src/Eloquent/Repository.php
+++ b/src/Eloquent/Repository.php
@@ -120,6 +120,15 @@ abstract class Repository implements RepositoryInterface, CriteriaInterface {
     }
 
     /**
+     * @param array $searchData
+     * @param array $saveData
+     * @return mixed
+     */
+    public function updateOrCreate(array $searchData, array $saveData = []) {
+        return $this->model->updateOrCreate($searchData, $saveData);
+    }
+
+    /**
      * @param  array  $data
      * @param  $id
      * @return mixed


### PR DESCRIPTION
The Repository class is missing a very useful function to be able to create
a model if it doesn't exist, or update it if it does.

The updateOrCreate($attributes, $values) function was added to the 
Repository contract and abstract class to account for this.