### PR TITLE
If you want to count the number of results from a relationship withou…

### DIFF
--- a/src/Bosnadev/Repositories/Eloquent/Repository.php
+++ b/src/Bosnadev/Repositories/Eloquent/Repository.php
@@ -86,6 +86,16 @@ abstract class Repository implements RepositoryInterface, CriteriaInterface
     }
 
     /**
+     * @param array $relations
+     * @return $this
+     */
+    public function withCount(array $relations)
+    {
+        $this->model = $this->model->withCount($relations);
+        return $this;
+    }
+
+    /**
      * @param  string $value
      * @param  string $key
      * @return array


### PR DESCRIPTION
…t actually loading them you may use the withCount method, which will place a {relation}_count column on your resulting models. It comes with Laravel 5.3. BTW thanks for this package.

--
I will do a few more pull requests in the coming days.